### PR TITLE
Refactor: Improve console logger clarity and test coverage

### DIFF
--- a/src/console-logger.ts
+++ b/src/console-logger.ts
@@ -19,5 +19,3 @@ export const consoleLogger = (message: string) => <T>(source: Observable<T>) =>
       }
     })
   )
-
-export const debug = consoleLogger

--- a/test/console-logger.spec.ts
+++ b/test/console-logger.spec.ts
@@ -2,14 +2,16 @@ import { expect } from 'chai'
 import { TestScheduler } from 'rxjs/testing'
 import { assert, createSandbox, SinonSandbox, SinonStub } from 'sinon'
 
-import { debug } from '../src/console-logger'
+import { consoleLogger } from '../src/console-logger'
 
-describe('debug', () => {
+describe('consoleLogger', () => {
   let scheduler: TestScheduler
   let sb: SinonSandbox
 
   let errorStub: SinonStub
   let logStub: SinonStub
+  let groupStub: SinonStub
+  let groupEndStub: SinonStub
 
   beforeEach(() => {
     scheduler = new TestScheduler((actual, expected) => void expect(actual).to.deep.equal(expected))
@@ -20,6 +22,8 @@ describe('debug', () => {
 
     errorStub = sb.stub(console, 'error')
     logStub = sb.stub(console, 'log')
+    groupStub = sb.stub(console, 'group')
+    groupEndStub = sb.stub(console, 'groupEnd')
   })
 
   afterEach(() => {
@@ -32,11 +36,13 @@ describe('debug', () => {
 
     const message = 'Test Message'
 
-    scheduler.expectObservable(source.pipe(debug(message))).toBe(expected)
+    scheduler.expectObservable(source.pipe(consoleLogger(message))).toBe(expected)
     scheduler.flush()
     assert.notCalled(errorStub)
-    assert.callCount(logStub, 3)
-    assert.calledWith(logStub, message)
+    assert.callCount(logStub, 2)
     assert.calledWith(logStub, message.concat(' Completed.'))
+    assert.calledOnce(groupStub)
+    assert.calledWith(groupStub, message)
+    assert.calledOnce(groupEndStub)
   })
 })


### PR DESCRIPTION
- I removed the `debug` alias for `consoleLogger` in `src/console-logger.ts` to improve clarity.
- I improved test coverage in `test/console-logger.spec.ts` by adding assertions for `console.group` and `console.groupEnd`.
- I updated tests to use `consoleLogger` instead of `debug`.